### PR TITLE
Add Kubernetes support

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ ImageWolf is a PoC that provides a blazingly fast way to get Docker images
 loaded onto your cluster, allowing updates to be pushed out quicker.
 
 ImageWolf works alongside existing registries such as the Docker Hub, Quay.io
-as well as self-hosted registries. 
+as well as self-hosted registries.
 
 The PoC for ImageWolf uses the BitTorrent protocol spread images around the
 cluster as they are pushed.
@@ -16,10 +16,10 @@ cluster as they are pushed.
 
 ## Getting Started
 
-The PoC was developed for Docker Swarm Mode. If there is sufficient interest,
-versions for Kubernetes and other cluster managers will follow. ImageWolf is
-currently alpha software and intended as a PoC - please don't run it in
+ImageWolf is currently alpha software and intended as a PoC - please don't run it in
 production!
+
+### Docker Swarm Mode
 
 To start ImageWolf, run the following on your Swarm master:
 
@@ -80,6 +80,49 @@ In order to monitor progress, you can either pass `-d=false` when starting the
 service or run `docker service ps test-service`. Note that nodes will reject
 jobs until ImageWolf completes loading the image onto the node.
 
+### Kubernetes
+
+In Kubernetes, there is the [DaemonSet](https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/)
+concept which ensures that all (or some) nodes run a copy of a pod. As nodes
+are added to the cluster, pods are added to them. As nodes are removed from the
+cluster, those pods are garbage collected.
+
+Then a [headless Service](https://kubernetes.io/docs/concepts/services-networking/service/#headless-services)
+is created allowing ImageWolf to discover all the peers.
+
+
+To start ImageWolf, deploy the DaemonSet and its associated headless Service using
+the following command:
+
+```
+kubectl apply -f kubernetes.yaml
+```
+
+Testing:
+
+```
+# You may need to wait few minutes before Kubernetes display the service public IP
+export IMAGEWOLF_IP=$(kubectl get svc imagewolf --no-headers | awk '{print $3}')
+
+# Simulate a Docker Hub webhook
+curl "${IMAGEWOLF_IP}/hubNotifications" \
+   -H 'Content-Type: application/json' \
+   -d '{
+      "push_data": {
+         "tag": "latest"
+      },
+      "repository": {
+         "repo_name": "redis"
+      }
+   }'
+
+# Inspect the logs
+kubectl logs -l app=imagewolf
+
+# Check the stats
+curl "${IMAGEWOLF_IP}/stats"
+```
+
 ## Integration with Docker Hub
 
 The Docker Hub has a web hooks feature which can be used to call a remote
@@ -108,7 +151,7 @@ the container will start immediately.
 ## Other Approaches
 
 Using a global or distributed file system to back a Docker registry can also
-achieve many of the benefits of ImageWolf. 
+achieve many of the benefits of ImageWolf.
 
 ## Multiarch
 
@@ -126,6 +169,7 @@ ImageWolf is a PoC currently and there are a lot of rough edges:
  - If ImageWolf is still distributing the image when a service is created, nodes
    will attempt to pull from the registry simultaneous with ImageWolf pushing
    the image
+ - Allow Google Cloud Platform container registry webhook using [Pub/Sub](https://cloud.google.com/container-registry/docs/configuring-notifications)
 
 Assuming there is interest in ImageWolf, the next step will be to change the hacked
 together code into a coherent solution.

--- a/build/Dockerfile.build
+++ b/build/Dockerfile.build
@@ -1,7 +1,27 @@
-FROM amouat/golang-multi
+FROM golang:1.7 AS build
 
-#COPY distribution /go/src/github.com/docker/distribution
+RUN go get github.com/anacrolix/utp
 RUN go get github.com/anacrolix/torrent/
 RUN go get github.com/docker/distribution/notifications
 COPY src/imagewolf.go /go/src/
 RUN CGO_ENABLED=0 go build -a /go/src/imagewolf.go
+
+FROM alpine:3.5 AS build-docker
+
+ENV DOCKER_VERSION 17.06.0
+ENV DOCKER_DOWNLOAD_URL https://download.docker.com/linux/static/stable/x86_64/docker-17.06.0-ce.tgz
+ENV DOCKER_DOWNLOAD_SHA e582486c9db0f4229deba9f8517145f8af6c5fae7a1243e6b07876bd3e706620
+
+RUN apk --update add ca-certificates wget
+RUN wget -O /docker.tgz "$DOCKER_DOWNLOAD_URL"
+RUN echo "$DOCKER_DOWNLOAD_SHA *docker.tgz" | sha256sum -c -;
+RUN tar xvpf docker.tgz
+
+
+# RUN
+FROM scratch
+
+ENV PATH "/"
+COPY --from=build /go/imagewolf /imagewolf
+COPY --from=build-docker /docker/docker /docker
+CMD ["/imagewolf"]

--- a/kubernetes.yaml
+++ b/kubernetes.yaml
@@ -1,0 +1,69 @@
+#
+# Listen to registry webhook
+#
+apiVersion: v1
+kind: Service
+metadata:
+  name: imagewolf
+  labels:
+    app: imagewolf
+spec:
+  type: LoadBalancer
+  ports:
+  - name: api-port
+    port: 80
+    targetPort: 8000
+  selector:
+    app: imagewolf
+---
+#
+# Headless service used to discover peers
+#
+apiVersion: v1
+kind: Service
+metadata:
+  name: imagewolf-headless
+  labels:
+    app: imagewolf
+spec:
+  clusterIP: None
+  ports:
+  - name: torrent-client
+    port: 6000
+    targetPort: 6000
+  selector:
+    app: imagewolf
+---
+#
+# DaemonSet to make sure we have ImageWolf deployed on every nodes
+#
+apiVersion: extensions/v1beta1
+kind: DaemonSet
+metadata:
+  name: imagewolf
+spec:
+  selector:
+    matchLabels:
+      app: imagewolf
+  template:
+    metadata:
+      name: imagewolf
+      labels:
+        app: imagewolf
+    spec:
+      containers:
+      - name: imagewolf
+        image: containersol/imagewolf-x86_64:latest
+        env:
+        - name: LOOKUP_HOST
+          value: imagewolf-headless
+        ports:
+        - containerPort: 6000
+        - containerPort: 8000
+        volumeMounts:
+        - name: docker
+          mountPath: /var/run/docker.sock
+      volumes:
+      - name: docker
+        hostPath:
+          path: /var/run/docker.sock

--- a/kubernetes.yaml
+++ b/kubernetes.yaml
@@ -53,10 +53,12 @@ spec:
     spec:
       containers:
       - name: imagewolf
-        image: containersol/imagewolf-x86_64:latest
+        image: moredhel/imagewolf:v8
         env:
         - name: LOOKUP_HOST
           value: imagewolf-headless
+        - name: DOCKER_API_VERSION
+          value: "1.23"
         ports:
         - containerPort: 6000
         - containerPort: 8000

--- a/src/imagewolf.go
+++ b/src/imagewolf.go
@@ -31,8 +31,16 @@ var torrentClient *torrent.Client
 var apiPort = 8000
 var dataDir = "/data"
 var myIps = make(map[string]bool)
+var lookupHost string
 
 func main() {
+	lookupHost = os.Getenv("LOOKUP_HOST")
+
+	if lookupHost == "" {
+		lookupHost = "tasks.imagewolf"
+	}
+
+	log.Printf("LOOKUP_HOST set to %s", lookupHost)
 
 	var clientConfig torrent.Config
 	clientConfig.DataDir = dataDir
@@ -97,10 +105,10 @@ func statsHandler(w http.ResponseWriter, r *http.Request) {
 
 func getPeers() {
 
-	ips, err := net.LookupIP("tasks.imagewolf")
+	ips, err := net.LookupIP(lookupHost)
 
 	if err != nil {
-		log.Printf("Error looking up tasks")
+		log.Printf("Error looking up hosts")
 		return
 	}
 


### PR DESCRIPTION
This PR add Kubernetes support to ImageWolf.

Make use of DaemonSet and headless Service for peer discovery.